### PR TITLE
Fix missing math functions on Windows.

### DIFF
--- a/soh/include/fp.h
+++ b/soh/include/fp.h
@@ -28,7 +28,5 @@ s32 lnearbyint(f64 x);
 
 f32 roundf(f32 x);
 f64 round(f64 x);
-s32 lroundf(f32 x);
-s32 lround(f64 x);
 
 #endif

--- a/soh/include/global.h
+++ b/soh/include/global.h
@@ -3,6 +3,8 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#include "math.h"
+
 #include "functions.h"
 #include "variables.h"
 #include "macros.h"


### PR DESCRIPTION
https://github.com/HarbourMasters/Shipwright/pull/1729 was building successfully on Windows but had all kinds of weird issues at runtime (random crashes, missing/glitchy visuals, incorrect collision, etc.) Not sure if this causes problems with other platforms, I can ifdef it if it does.